### PR TITLE
feat: add Bark app support

### DIFF
--- a/Drivers/Bark.cs
+++ b/Drivers/Bark.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace vPilot_Pushover.Drivers {
+    internal class Bark : HttpNotifierBase {
+
+        private string _url;
+        private string _key;
+
+        protected override void Configure(NotifierConfig config) {
+            _url = config.BarkUrl;
+            _key = config.BarkKey;
+        }
+
+        public override bool HasValidConfig() {
+            return !string.IsNullOrWhiteSpace(_url) && !string.IsNullOrWhiteSpace(_key);
+        }
+
+        public override async Task SendMessageAsync(string text, string title = "", int priority = 0, string source = "notification") {
+            // Bark notification priority levels, obtained from Bark docs:
+            // critical: Important alert, will ring even in silent mode
+            // timeSensitiv: Time-sensitive notification, can display the notification in focus mode.
+            // active: Default value, the system will immediately light up the screen to display the notification
+            // passive: Only adds the notification to the notification list, will not light up the screen.
+
+            string level = priority == -1 ? "passive"
+                         : priority ==  1 ? "timeSensitive"
+                         : priority ==  2 ? "critical"
+                         : "active"; // defaults to "active", including priority = 0
+
+            // Bark Request Parameters, see Bark docs for details:
+            // https://bark.day.app/#/en-us/tutorial?id=request-parameters
+            var values = new Dictionary<string, string> {
+                { "title", title },
+                { "body", text },
+                { "level", level }
+            };
+
+            // Prevents double-slashes if user leaves a trailing slash in the config URL
+            await PostFormAsync($"{_url.TrimEnd('/')}/{_key}", values, source);
+        }
+    }
+}

--- a/Drivers/Bark.cs
+++ b/Drivers/Bark.cs
@@ -6,10 +6,12 @@ namespace vPilot_Pushover.Drivers {
 
         private string _url;
         private string _key;
+        private string _notificationGroup;
 
         protected override void Configure(NotifierConfig config) {
             _url = config.BarkUrl;
             _key = config.BarkKey;
+            _notificationGroup = config.BarkNotificationGroup;
         }
 
         public override bool HasValidConfig() {
@@ -33,7 +35,8 @@ namespace vPilot_Pushover.Drivers {
             var values = new Dictionary<string, string> {
                 { "title", title },
                 { "body", text },
-                { "level", level }
+                { "level", level },
+                { "group", _notificationGroup } // Groups notifications in iOS notification centre
             };
 
             // Prevents double-slashes if user leaves a trailing slash in the config URL

--- a/Drivers/Bark.cs
+++ b/Drivers/Bark.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace vPilot_Pushover.Drivers {
     internal class Bark : HttpNotifierBase {
@@ -41,6 +42,33 @@ namespace vPilot_Pushover.Drivers {
 
             // Prevents double-slashes if user leaves a trailing slash in the config URL
             await PostFormAsync($"{_url.TrimEnd('/')}/{_key}", values, source);
+        }
+
+        // Parse error text to improve user readability
+        protected override string ExtractErrorDetail(string body) {
+            // Ensure error message is not null, and trim whitespace
+            string error = (body ?? "").Trim();
+            
+            // Extract the JSON "message" field if it exists
+            var match = Regex.Match(error, "\"message\"\\s*:\\s*\"([^\"]*)\"");
+            if (match.Success) error = match.Groups[1].Value ;
+
+            if (error.Contains("failed to get device token")) {
+                return $"The Bark server rejected your API Key ({_key}). Please verify your Bark API Key is correctly configured in vPilot-Pushover.ini.";
+            }
+
+            // Handle edge cases where API server is incorrectly configured
+            // 1. Empty response
+            if (error == "" || error == "{}") {
+                return "The server returned an empty response. Please verify your Bark API URL is correctly configured in vPilot-Pushover.ini.";
+            }
+
+            // 2. HTML web pages, e.g. <!DOCTYPE html>
+            if (error.StartsWith("<")) {
+                return "The server returned a web page instead of an API response. Please verify your Bark API URL is correctly configured in vPilot-Pushover.ini.";
+            }
+
+            return error;
         }
     }
 }

--- a/Drivers/HttpNotifierBase.cs
+++ b/Drivers/HttpNotifierBase.cs
@@ -38,7 +38,7 @@ namespace vPilot_Pushover.Drivers {
                     }
                 }
             } catch (Exception ex) {
-                _onError?.Invoke($"{GetType().Name} failed sending the {source}: {ex.Message}");
+                _onError?.Invoke($"{GetType().Name} failed sending the {source}: {ex.GetBaseException().Message}");
             }
         }
 

--- a/Main.cs
+++ b/Main.cs
@@ -32,6 +32,8 @@ namespace vPilot_Pushover {
         public string TelegramChatId { get; set; }
         public string GotifyUrl { get; set; }
         public string GotifyToken { get; set; }
+        public string BarkUrl { get; set; }
+        public string BarkKey { get; set; }
 
         // Per-message-type priority, passed through to the driver.
         // Driver semantics: Pushover -2..2, Gotify 0..10, Telegram ignored.
@@ -83,6 +85,18 @@ namespace vPilot_Pushover {
                         n.Initialize(new NotifierConfig {
                             GotifyUrl = s.GotifyUrl,
                             GotifyToken = s.GotifyToken,
+                            OnError = onError
+                        });
+                        return n;
+                    }
+                },
+                {
+                    "bark",
+                    (s, onError) => {
+                        var n = new Drivers.Bark();
+                        n.Initialize(new NotifierConfig {
+                            BarkUrl = s.BarkUrl,
+                            BarkKey = s.BarkKey,
                             OnError = onError
                         });
                         return n;
@@ -232,6 +246,8 @@ namespace vPilot_Pushover {
                     DisconnectEnabled = ParseBool(ini.Read("Enabled", "Disconnect", null)),
                     GotifyUrl = ini.Read("Url", "Gotify", null),
                     GotifyToken = ini.Read("Token", "Gotify", null),
+                    BarkUrl = ini.Read("Url", "Bark", null),
+                    BarkKey = ini.Read("Key", "Bark", null),
 
                     PrivatePriority = ParseInt(ini.Read("Priority", "RelayPrivate", null), 1),
                     RadioPriority = ParseInt(ini.Read("Priority", "RelayRadio", null), 1),

--- a/Main.cs
+++ b/Main.cs
@@ -34,6 +34,7 @@ namespace vPilot_Pushover {
         public string GotifyToken { get; set; }
         public string BarkUrl { get; set; }
         public string BarkKey { get; set; }
+        public string BarkNotificationGroup { get; set; }
 
         // Per-message-type priority, passed through to the driver.
         // Driver semantics: Pushover -2..2, Gotify 0..10, Telegram ignored.
@@ -97,6 +98,7 @@ namespace vPilot_Pushover {
                         n.Initialize(new NotifierConfig {
                             BarkUrl = s.BarkUrl,
                             BarkKey = s.BarkKey,
+                            BarkNotificationGroup = s.BarkNotificationGroup,
                             OnError = onError
                         });
                         return n;
@@ -248,6 +250,7 @@ namespace vPilot_Pushover {
                     GotifyToken = ini.Read("Token", "Gotify", null),
                     BarkUrl = ini.Read("Url", "Bark", null),
                     BarkKey = ini.Read("Key", "Bark", null),
+                    BarkNotificationGroup = ini.Read("NotificationGroup", "Bark", null),
 
                     PrivatePriority = ParseInt(ini.Read("Priority", "RelayPrivate", null), 1),
                     RadioPriority = ParseInt(ini.Read("Priority", "RelayRadio", null), 1),

--- a/NotifierConfig.cs
+++ b/NotifierConfig.cs
@@ -12,6 +12,8 @@ namespace vPilot_Pushover {
         public string TelegramChatId { get; set; }
         public string GotifyUrl { get; set; }
         public string GotifyToken { get; set; }
+        public string BarkUrl { get; set; }
+        public string BarkKey { get; set; }
 
         // Invoked by a driver when a send fails, so the host can log and notify the user.
         public Action<string> OnError { get; set; }

--- a/NotifierConfig.cs
+++ b/NotifierConfig.cs
@@ -14,6 +14,7 @@ namespace vPilot_Pushover {
         public string GotifyToken { get; set; }
         public string BarkUrl { get; set; }
         public string BarkKey { get; set; }
+        public string BarkNotificationGroup { get; set; }
 
         // Invoked by a driver when a send fails, so the host can log and notify the user.
         public Action<string> OnError { get; set; }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vPilot Pushover
 [![Github All Releases](https://img.shields.io/github/downloads/blt950/vPilot-Pushover/total.svg)]()
 
-Relay [vPilot](https://vpilot.rosscarlson.dev/) and [Hoppie](https://www.hoppie.nl/acars/) messages to your mobile device via [Pushover](https://pushover.net/), [Telegram](https://telegram.org/) or [Gotify](https://gotify.net/).\
+Relay [vPilot](https://vpilot.rosscarlson.dev/) and [Hoppie](https://www.hoppie.nl/acars/) messages to your mobile device via [Pushover](https://pushover.net/), [Telegram](https://telegram.org/), [Gotify](https://gotify.net/) or [Bark](https://bark.day.app/#/en-us/?id=bark).\
 Hoppie is integrated directly, meaning you can use any aircraft with this plugin.
 
 ![Image of example notification of contact me](https://github.com/blt950/vPilot-Pushover/assets/2505044/68653e8a-8bca-45d4-8220-4a38f39d68d4)
@@ -23,6 +23,10 @@ You need [vPilot](https://vpilot.rosscarlson.dev/) that you use to connect to VA
 - It's required to install gotify server beforehand. Check [Gotify Docs](https://gotify.net/docs/index) for more infomation
 - Please note that only Android phone is officially supported by them. See [this](https://github.com/gotify/android)
 
+### Bark
+- Install the iOS App from the [App Store](https://apps.apple.com/us/app/bark-custom-notifications/id1403753865)
+- (Optional) Set up a self-hosted backend server using [Finb/bark-server](https://github.com/Finb/bark-server) following the [Deployment Guide](https://bark.day.app/#/en-us/deploy)
+
 ## Installation
 
 1. Make sure your vPilot is not running
@@ -34,10 +38,10 @@ You need [vPilot](https://vpilot.rosscarlson.dev/) that you use to connect to VA
 ## Settings
 In the `vPilot-Pushover.ini` file, you can configure the following settings:
 
-Several message types below take a `Priority` value that controls how urgently the notification is delivered. This is only used by **Pushover** ([`-2` to `2`](https://pushover.net/api#priority)) and **Gotify** ([`0` to `10`](https://gotify.net/docs/priority)); **Telegram** ignores it. For Pushover, priority `2` is an emergency notification that repeats using the `HighPriRetries`/`HighPriExpire` settings until you acknowledge it.
+Several message types below take a `Priority` value that controls how urgently the notification is delivered. This is only used by **Pushover** ([`-2` to `2`](https://pushover.net/api#priority)), **Gotify** ([`0` to `10`](https://gotify.net/docs/priority)) and **Bark** (`-1` to `2`, mapping to `passive`, `active`, `timeSensitive` and `critical` levels - [see docs](https://bark.day.app/#/en-us/tutorial?id=request-parameters)); **Telegram** ignores it. For Pushover, priority `2` is an emergency notification that repeats using the `HighPriRetries`/`HighPriExpire` settings until you acknowledge it.
 
 ### [General]
-`Driver` = Choose your notifier method, write `pushover`, `telegram` or `gotify` in lowercase.
+`Driver` = Choose your notifier method, write `pushover`, `telegram`, `gotify` or `bark` in lowercase.
 
 ### [Pushover]
 `UserKey` = Your Pushover user key. You can find this on the [Pushover dashboard](https://pushover.net/)\
@@ -53,6 +57,10 @@ Several message types below take a `Priority` value that controls how urgently t
 ### [Gotify]
 `Url` = Your Gotify server address. For example, `https://push.example.com`, `https://example.com/gotify`, depending on your server configuration.\
 `Token` = Your Gotify application token. see [this](https://gotify.net/docs/pushmsg)
+
+### [Bark]
+`Url` = Your Bark server address. Defaults to `https://api.day.app` unless you self-host a backend server with a custom domain.\
+`Key` = Your Bark push key. Follow the [Tutorial](https://bark.day.app/#/en-us/tutorial) to obtain your key.
 
 ### [Hoppie]
 `Enabled` = Whether or not to relay Hoppie messages. Set to `true` or `false`\

--- a/bin/Debug/vPilot-Pushover.ini
+++ b/bin/Debug/vPilot-Pushover.ini
@@ -15,6 +15,7 @@ ChatId=
 [Bark]
 Url=https://api.day.app
 Key=
+NotificationGroup=vPilot
 
 [Gotify]
 Url=

--- a/bin/Debug/vPilot-Pushover.ini
+++ b/bin/Debug/vPilot-Pushover.ini
@@ -12,6 +12,10 @@ HighPriExpire=300
 BotToken=
 ChatId=
 
+[Bark]
+Url=https://api.day.app
+Key=
+
 [Gotify]
 Url=
 Token=

--- a/bin/Release/vPilot-Pushover.ini
+++ b/bin/Release/vPilot-Pushover.ini
@@ -12,10 +12,10 @@ HighPriExpire=300
 BotToken=
 ChatId=
 
-
 [Bark]
 Url=https://api.day.app
 Key=
+NotificationGroup=vPilot
 
 [Gotify]
 Url=

--- a/bin/Release/vPilot-Pushover.ini
+++ b/bin/Release/vPilot-Pushover.ini
@@ -12,6 +12,11 @@ HighPriExpire=300
 BotToken=
 ChatId=
 
+
+[Bark]
+Url=https://api.day.app
+Key=
+
 [Gotify]
 Url=
 Token=

--- a/vPilot-Pushover.csproj
+++ b/vPilot-Pushover.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Drivers\Gotify.cs" />
     <Compile Include="Drivers\Pushover.cs" />
     <Compile Include="Drivers\Telegram.cs" />
+    <Compile Include="Drivers\Bark.cs" />
     <Compile Include="Http.cs" />
     <Compile Include="IniFile.cs" />
     <Compile Include="INotifier.cs" />


### PR DESCRIPTION
# Overview
This PR adds [Bark](https://bark.day.app/#/en-us/) as a supported notifier driver, together with updated README and `.ini` configuration files. 

Bark is an [open-source](https://github.com/finb/bark) iOS notification app, with an optional [self-hosted backend server](https://github.com/Finb/bark-server). It can be found on the [App Store](https://apps.apple.com/us/app/bark-custom-notifications/id1403753865).

# Key Details
- As priority levels in Bark are non-numerical, I have mapped numerical values `-1` to `2` to Bark's `passive`, `active`, `timeSensitive`, and `critical` levels respectively.
- An optional `NotificationGroup` parameter allows vPilot notifications to stay organised together in the iOS Notification Centre and Bark app.
- I may consider adding other parameters (like custom icons) in the future - see [the docs](https://bark.day.app/#/en-us/tutorial?id=request-parameters) for available options.

# Testing
I have successfully compiled the plugin and verified it is able to deliver notifications to my iPhone, including "Time Sensitive" and "Critical" alerts.