### PR TITLE
Add mqtt broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs/
+Directory.Build.props
 bin/Debug/*
 bin/Release/*
 obj/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"dotnet.preferCSharpExtension": true
+}

--- a/Directory.Build.props.example
+++ b/Directory.Build.props.example
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- Change this to the vPilot SDK DLL on your development machine. -->
+    <VpilotPluginsPath>F:\VATSIM\vPilot\RossCarlson.Vatsim.Vpilot.Plugins.dll</VpilotPluginsPath>
+  </PropertyGroup>
+</Project>

--- a/Drivers/Mqtt.cs
+++ b/Drivers/Mqtt.cs
@@ -7,8 +7,10 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Web.Script.Serialization;
 
-namespace vPilot_Pushover.Drivers {
-    internal class Mqtt : INotifier {
+namespace vPilot_Pushover.Drivers
+{
+    internal class Mqtt : INotifier
+    {
         private string _host;
         private int _port;
         private string _topic;
@@ -17,30 +19,43 @@ namespace vPilot_Pushover.Drivers {
         private bool _useTls;
         private Action<string> _onError;
 
-        public void Initialize(NotifierConfig config) {
+        public void Initialize(NotifierConfig config)
+        {
             _host = config.MqttHost;
             _topic = config.MqttTopic;
             _username = config.MqttUsername;
             _password = config.MqttPassword;
             _useTls = bool.TryParse(config.MqttUseTls, out bool useTls) && useTls;
-            if (!int.TryParse(config.MqttPort, out _port)) _port = _useTls ? 8883 : 1883;
+            if (!int.TryParse(config.MqttPort, out _port))
+            {
+                _port = _useTls ? 8883 : 1883;
+            }
+
             _onError = config.OnError;
         }
 
-        public bool HasValidConfig() {
-            return !string.IsNullOrWhiteSpace(_host) && !string.IsNullOrWhiteSpace(_topic) &&
-                _port > 0 && _port <= 65535 &&
-                ((_username == null && _password == null) ||
-                 (!string.IsNullOrWhiteSpace(_username) && _password != null));
+        public bool HasValidConfig()
+        {
+            return !string.IsNullOrWhiteSpace(_host)
+                && !string.IsNullOrWhiteSpace(_topic)
+                && _port > 0
+                && _port <= 65535
+                && ((_username == null && _password == null)
+                    || (!string.IsNullOrWhiteSpace(_username) && _password != null));
         }
 
-        public async Task SendMessageAsync(string text, string title = "", int priority = 0, string source = "notification") {
-            try {
-                using (var client = new TcpClient()) {
+        public async Task SendMessageAsync(string text, string title = "", int priority = 0, string source = "notification")
+        {
+            try
+            {
+                using (var client = new TcpClient())
+                {
                     await client.ConnectAsync(_host, _port);
-                    using (var networkStream = client.GetStream()) {
+                    using (var networkStream = client.GetStream())
+                    {
                         Stream stream = networkStream;
-                        if (_useTls) {
+                        if (_useTls)
+                        {
                             var sslStream = new SslStream(networkStream, false);
                             await sslStream.AuthenticateAsClientAsync(_host, null, SslProtocols.Tls12, false);
                             stream = sslStream;
@@ -48,11 +63,13 @@ namespace vPilot_Pushover.Drivers {
 
                         await WritePacketAsync(stream, CreateConnectPacket("vPilot-Pushover-" + Guid.NewGuid().ToString("N")));
                         byte[] connAck = await ReadBytesAsync(stream, 4);
-                        if (connAck[0] != 0x20 || connAck[1] != 0x02 || connAck[3] != 0) {
+                        if (connAck[0] != 0x20 || connAck[1] != 0x02 || connAck[3] != 0)
+                        {
                             throw new InvalidOperationException($"MQTT broker rejected the connection (return code {connAck[3]}).");
                         }
 
-                        string payload = new JavaScriptSerializer().Serialize(new {
+                        string payload = new JavaScriptSerializer().Serialize(new
+                        {
                             title,
                             message = text,
                             priority,
@@ -62,22 +79,32 @@ namespace vPilot_Pushover.Drivers {
                         await WritePacketAsync(stream, new byte[] { 0xE0, 0x00 });
                     }
                 }
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 _onError?.Invoke($"{GetType().Name} failed sending the {source}: {ex.GetBaseException().Message}");
             }
         }
 
-        private byte[] CreateConnectPacket(string clientId) {
-            using (var payload = new MemoryStream()) {
+        private byte[] CreateConnectPacket(string clientId)
+        {
+            using (var payload = new MemoryStream())
+            {
                 WriteString(payload, clientId);
-                if (_username != null) {
+                if (_username != null)
+                {
                     WriteString(payload, _username);
-                    WriteString(payload, _password ?? "");
+                    WriteString(payload, _password ?? string.Empty);
                 }
 
                 byte flags = 0x02;
-                if (_username != null) flags |= 0xC0;
-                using (var packet = new MemoryStream()) {
+                if (_username != null)
+                {
+                    flags |= 0xC0;
+                }
+
+                using (var packet = new MemoryStream())
+                {
                     WriteString(packet, "MQTT");
                     packet.WriteByte(0x04);
                     packet.WriteByte(flags);
@@ -90,17 +117,21 @@ namespace vPilot_Pushover.Drivers {
             }
         }
 
-        private byte[] CreatePublishPacket(string payloadText) {
-            using (var body = new MemoryStream()) {
+        private byte[] CreatePublishPacket(string payloadText)
+        {
+            using (var body = new MemoryStream())
+            {
                 WriteString(body, _topic);
-            byte[] payload = Encoding.UTF8.GetBytes(payloadText);
+                byte[] payload = Encoding.UTF8.GetBytes(payloadText);
                 body.Write(payload, 0, payload.Length);
                 return AddHeader(0x30, body.ToArray());
             }
         }
 
-        private static byte[] AddHeader(byte packetType, byte[] body) {
-            using (var packet = new MemoryStream()) {
+        private static byte[] AddHeader(byte packetType, byte[] body)
+        {
+            using (var packet = new MemoryStream())
+            {
                 packet.WriteByte(packetType);
                 WriteRemainingLength(packet, body.Length);
                 packet.Write(body, 0, body.Length);
@@ -108,35 +139,51 @@ namespace vPilot_Pushover.Drivers {
             }
         }
 
-        private static void WriteString(Stream stream, string value) {
+        private static void WriteString(Stream stream, string value)
+        {
             byte[] bytes = Encoding.UTF8.GetBytes(value);
             stream.WriteByte((byte)(bytes.Length >> 8));
             stream.WriteByte((byte)bytes.Length);
             stream.Write(bytes, 0, bytes.Length);
         }
 
-        private static void WriteRemainingLength(Stream stream, int length) {
-            do {
+        private static void WriteRemainingLength(Stream stream, int length)
+        {
+            do
+            {
                 int encodedByte = length % 128;
                 length /= 128;
-                if (length > 0) encodedByte |= 128;
+                if (length > 0)
+                {
+                    encodedByte |= 128;
+                }
+
                 stream.WriteByte((byte)encodedByte);
-            } while (length > 0);
+            }
+            while (length > 0);
         }
 
-        private static async Task WritePacketAsync(Stream stream, byte[] packet) {
+        private static async Task WritePacketAsync(Stream stream, byte[] packet)
+        {
             await stream.WriteAsync(packet, 0, packet.Length);
             await stream.FlushAsync();
         }
 
-        private static async Task<byte[]> ReadBytesAsync(Stream stream, int count) {
+        private static async Task<byte[]> ReadBytesAsync(Stream stream, int count)
+        {
             var result = new byte[count];
             int offset = 0;
-            while (offset < count) {
+            while (offset < count)
+            {
                 int read = await stream.ReadAsync(result, offset, count - offset);
-                if (read == 0) throw new EndOfStreamException("The MQTT broker closed the connection.");
+                if (read == 0)
+                {
+                    throw new EndOfStreamException("The MQTT broker closed the connection.");
+                }
+
                 offset += read;
             }
+
             return result;
         }
     }

--- a/Drivers/Mqtt.cs
+++ b/Drivers/Mqtt.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace vPilot_Pushover.Drivers {
+    internal class Mqtt : INotifier {
+        private string _host;
+        private int _port;
+        private string _topic;
+        private string _username;
+        private string _password;
+        private bool _useTls;
+        private Action<string> _onError;
+
+        public void Initialize(NotifierConfig config) {
+            _host = config.MqttHost;
+            _topic = config.MqttTopic;
+            _username = config.MqttUsername;
+            _password = config.MqttPassword;
+            _useTls = bool.TryParse(config.MqttUseTls, out bool useTls) && useTls;
+            if (!int.TryParse(config.MqttPort, out _port)) _port = _useTls ? 8883 : 1883;
+            _onError = config.OnError;
+        }
+
+        public bool HasValidConfig() {
+            return !string.IsNullOrWhiteSpace(_host) && !string.IsNullOrWhiteSpace(_topic) &&
+                _port > 0 && _port <= 65535 &&
+                ((_username == null && _password == null) ||
+                 (!string.IsNullOrWhiteSpace(_username) && _password != null));
+        }
+
+        public async Task SendMessageAsync(string text, string title = "", int priority = 0, string source = "notification") {
+            try {
+                using (var client = new TcpClient()) {
+                    await client.ConnectAsync(_host, _port);
+                    using (var networkStream = client.GetStream()) {
+                        Stream stream = networkStream;
+                        if (_useTls) {
+                            var sslStream = new SslStream(networkStream, false);
+                            await sslStream.AuthenticateAsClientAsync(_host, null, SslProtocols.Tls12, false);
+                            stream = sslStream;
+                        }
+
+                        await WritePacketAsync(stream, CreateConnectPacket("vPilot-Pushover-" + Guid.NewGuid().ToString("N")));
+                        byte[] connAck = await ReadBytesAsync(stream, 4);
+                        if (connAck[0] != 0x20 || connAck[1] != 0x02 || connAck[3] != 0) {
+                            throw new InvalidOperationException($"MQTT broker rejected the connection (return code {connAck[3]}).");
+                        }
+
+                        string message = string.IsNullOrEmpty(title) ? text : $"{title}\n\n{text}";
+                        await WritePacketAsync(stream, CreatePublishPacket(message));
+                        await WritePacketAsync(stream, new byte[] { 0xE0, 0x00 });
+                    }
+                }
+            } catch (Exception ex) {
+                _onError?.Invoke($"{GetType().Name} failed sending the {source}: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private byte[] CreateConnectPacket(string clientId) {
+            using (var payload = new MemoryStream()) {
+                WriteString(payload, clientId);
+                if (_username != null) {
+                    WriteString(payload, _username);
+                    WriteString(payload, _password ?? "");
+                }
+
+                byte flags = 0x02;
+                if (_username != null) flags |= 0xC0;
+                using (var packet = new MemoryStream()) {
+                    WriteString(packet, "MQTT");
+                    packet.WriteByte(0x04);
+                    packet.WriteByte(flags);
+                    packet.WriteByte(0x00);
+                    packet.WriteByte(0x1E);
+                    payload.Position = 0;
+                    payload.CopyTo(packet);
+                    return AddHeader(0x10, packet.ToArray());
+                }
+            }
+        }
+
+        private byte[] CreatePublishPacket(string message) {
+            using (var body = new MemoryStream()) {
+                WriteString(body, _topic);
+                byte[] payload = Encoding.UTF8.GetBytes(message);
+                body.Write(payload, 0, payload.Length);
+                return AddHeader(0x30, body.ToArray());
+            }
+        }
+
+        private static byte[] AddHeader(byte packetType, byte[] body) {
+            using (var packet = new MemoryStream()) {
+                packet.WriteByte(packetType);
+                WriteRemainingLength(packet, body.Length);
+                packet.Write(body, 0, body.Length);
+                return packet.ToArray();
+            }
+        }
+
+        private static void WriteString(Stream stream, string value) {
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            stream.WriteByte((byte)(bytes.Length >> 8));
+            stream.WriteByte((byte)bytes.Length);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static void WriteRemainingLength(Stream stream, int length) {
+            do {
+                int encodedByte = length % 128;
+                length /= 128;
+                if (length > 0) encodedByte |= 128;
+                stream.WriteByte((byte)encodedByte);
+            } while (length > 0);
+        }
+
+        private static async Task WritePacketAsync(Stream stream, byte[] packet) {
+            await stream.WriteAsync(packet, 0, packet.Length);
+            await stream.FlushAsync();
+        }
+
+        private static async Task<byte[]> ReadBytesAsync(Stream stream, int count) {
+            var result = new byte[count];
+            int offset = 0;
+            while (offset < count) {
+                int read = await stream.ReadAsync(result, offset, count - offset);
+                if (read == 0) throw new EndOfStreamException("The MQTT broker closed the connection.");
+                offset += read;
+            }
+            return result;
+        }
+    }
+}

--- a/Drivers/Mqtt.cs
+++ b/Drivers/Mqtt.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web.Script.Serialization;
 
 namespace vPilot_Pushover.Drivers {
     internal class Mqtt : INotifier {
@@ -51,8 +52,13 @@ namespace vPilot_Pushover.Drivers {
                             throw new InvalidOperationException($"MQTT broker rejected the connection (return code {connAck[3]}).");
                         }
 
-                        string message = string.IsNullOrEmpty(title) ? text : $"{title}\n\n{text}";
-                        await WritePacketAsync(stream, CreatePublishPacket(message));
+                        string payload = new JavaScriptSerializer().Serialize(new {
+                            title,
+                            message = text,
+                            priority,
+                            source
+                        });
+                        await WritePacketAsync(stream, CreatePublishPacket(payload));
                         await WritePacketAsync(stream, new byte[] { 0xE0, 0x00 });
                     }
                 }
@@ -84,10 +90,10 @@ namespace vPilot_Pushover.Drivers {
             }
         }
 
-        private byte[] CreatePublishPacket(string message) {
+        private byte[] CreatePublishPacket(string payloadText) {
             using (var body = new MemoryStream()) {
                 WriteString(body, _topic);
-                byte[] payload = Encoding.UTF8.GetBytes(message);
+            byte[] payload = Encoding.UTF8.GetBytes(payloadText);
                 body.Write(payload, 0, payload.Length);
                 return AddHeader(0x30, body.ToArray());
             }

--- a/Main.cs
+++ b/Main.cs
@@ -36,6 +36,12 @@ namespace vPilot_Pushover {
         public string BarkUrl { get; set; }
         public string BarkKey { get; set; }
         public string BarkNotificationGroup { get; set; }
+        public string MqttHost { get; set; }
+        public string MqttPort { get; set; }
+        public string MqttTopic { get; set; }
+        public string MqttUsername { get; set; }
+        public string MqttPassword { get; set; }
+        public string MqttUseTls { get; set; }
 
         // Per-message-type priority, passed through to the driver.
         // Driver semantics: Pushover -2..2, Gotify 0..10, Telegram ignored.
@@ -100,6 +106,22 @@ namespace vPilot_Pushover {
                             BarkUrl = s.BarkUrl,
                             BarkKey = s.BarkKey,
                             BarkNotificationGroup = s.BarkNotificationGroup,
+                            OnError = onError
+                        });
+                        return n;
+                    }
+                },
+                {
+                    "mqtt",
+                    (s, onError) => {
+                        var n = new Drivers.Mqtt();
+                        n.Initialize(new NotifierConfig {
+                            MqttHost = s.MqttHost,
+                            MqttPort = s.MqttPort,
+                            MqttTopic = s.MqttTopic,
+                            MqttUsername = s.MqttUsername,
+                            MqttPassword = s.MqttPassword,
+                            MqttUseTls = s.MqttUseTls,
                             OnError = onError
                         });
                         return n;
@@ -260,6 +282,12 @@ namespace vPilot_Pushover {
                     BarkUrl = ini.Read("Url", "Bark", null),
                     BarkKey = ini.Read("Key", "Bark", null),
                     BarkNotificationGroup = ini.Read("NotificationGroup", "Bark", null),
+                    MqttHost = ini.Read("Host", "MQTT", null),
+                    MqttPort = ini.Read("Port", "MQTT", null),
+                    MqttTopic = ini.Read("Topic", "MQTT", null),
+                    MqttUsername = ini.Read("Username", "MQTT", null),
+                    MqttPassword = ini.Read("Password", "MQTT", null),
+                    MqttUseTls = ini.Read("UseTls", "MQTT", null),
 
                     PrivatePriority = ParseInt(ini.Read("Priority", "RelayPrivate", null), 1),
                     RadioPriority = ParseInt(ini.Read("Priority", "RelayRadio", null), 1),

--- a/NotifierConfig.cs
+++ b/NotifierConfig.cs
@@ -15,6 +15,12 @@ namespace vPilot_Pushover {
         public string BarkUrl { get; set; }
         public string BarkKey { get; set; }
         public string BarkNotificationGroup { get; set; }
+        public string MqttHost { get; set; }
+        public string MqttPort { get; set; }
+        public string MqttTopic { get; set; }
+        public string MqttUsername { get; set; }
+        public string MqttPassword { get; set; }
+        public string MqttUseTls { get; set; }
 
         // Invoked by a driver when a send fails, so the host can log and notify the user.
         public Action<string> OnError { get; set; }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You need [vPilot](https://vpilot.rosscarlson.dev/) that you use to connect to VA
 
 ### MQTT
 - Use any MQTT 3.1.1-compatible broker. Messages are published at QoS 0.
+- The payload is JSON with separate `title`, `message`, `priority`, and `source` properties.
 - TLS is supported with broker hostname certificate validation.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vPilot Pushover
 [![Github All Releases](https://img.shields.io/github/downloads/blt950/vPilot-Pushover/total.svg)]()
 
-Relay [vPilot](https://vpilot.rosscarlson.dev/) and [Hoppie](https://www.hoppie.nl/acars/) messages to your mobile device via [Pushover](https://pushover.net/), [Telegram](https://telegram.org/), [Gotify](https://gotify.net/) or [Bark](https://bark.day.app/#/en-us/?id=bark).\
+Relay [vPilot](https://vpilot.rosscarlson.dev/) and [Hoppie](https://www.hoppie.nl/acars/) messages to your mobile device via [Pushover](https://pushover.net/), [Telegram](https://telegram.org/), [Gotify](https://gotify.net/) or [Bark](https://bark.day.app/#/en-us/?id=bark), or publish them to an MQTT broker.\
 Hoppie is integrated directly, meaning you can use any aircraft with this plugin.
 
 ![Image of example notification of contact me](https://github.com/blt950/vPilot-Pushover/assets/2505044/68653e8a-8bca-45d4-8220-4a38f39d68d4)
@@ -27,6 +27,10 @@ You need [vPilot](https://vpilot.rosscarlson.dev/) that you use to connect to VA
 - Install the iOS App from the [App Store](https://apps.apple.com/us/app/bark-custom-notifications/id1403753865)
 - (Optional) Set up a self-hosted backend server using [Finb/bark-server](https://github.com/Finb/bark-server) following the [Deployment Guide](https://bark.day.app/#/en-us/deploy)
 
+### MQTT
+- Use any MQTT 3.1.1-compatible broker. Messages are published at QoS 0.
+- TLS is supported with broker hostname certificate validation.
+
 ## Installation
 
 1. Make sure your vPilot is not running
@@ -35,13 +39,29 @@ You need [vPilot](https://vpilot.rosscarlson.dev/) that you use to connect to VA
 4. Open `vPilot-Pushover.ini` in a text editor and configure your desired [settings](#settings)
 5. When you start vPilot you should now get an "Connected. Running version x.x.x" push notification. If not, see [troubleshooting](#troubleshooting) below.
 
+## Building
+
+The project references the vPilot SDK assembly used by the plugin API. Its location is different between developer machines, so it is not hard-coded in the project file.
+
+1. Copy `Directory.Build.props.example` to `Directory.Build.props`.
+2. Set `VpilotPluginsPath` to the full path of `RossCarlson.Vatsim.Vpilot.Plugins.dll` on your machine.
+3. Run `dotnet build`.
+
+You can also set the path for one build without creating the local props file:
+
+```powershell
+dotnet build -p:VpilotPluginsPath="C:\path\to\RossCarlson.Vatsim.Vpilot.Plugins.dll"
+```
+
+The `VPILOT_PLUGINS_DLL` environment variable is also supported.
+
 ## Settings
 In the `vPilot-Pushover.ini` file, you can configure the following settings:
 
 Several message types below take a `Priority` value that controls how urgently the notification is delivered. This is only used by **Pushover** ([`-2` to `2`](https://pushover.net/api#priority)), **Gotify** ([`0` to `10`](https://gotify.net/docs/priority)) and **Bark** (`-1` to `2`, mapping to `passive`, `active`, `timeSensitive` and `critical` levels - [see docs](https://bark.day.app/#/en-us/tutorial?id=request-parameters)); **Telegram** ignores it. For Pushover, priority `2` is an emergency notification that repeats using the `HighPriRetries`/`HighPriExpire` settings until you acknowledge it.
 
 ### [General]
-`Driver` = Choose your notifier method, write `pushover`, `telegram`, `gotify` or `bark` in lowercase.
+`Driver` = Choose your notifier method, write `pushover`, `telegram`, `gotify`, `bark` or `mqtt` in lowercase.
 
 ### [Pushover]
 `UserKey` = Your Pushover user key. You can find this on the [Pushover dashboard](https://pushover.net/)\
@@ -61,6 +81,14 @@ Several message types below take a `Priority` value that controls how urgently t
 ### [Bark]
 `Url` = Your Bark server address. Defaults to `https://api.day.app` unless you self-host a backend server with a custom domain.\
 `Key` = Your Bark push key. Follow the [Tutorial](https://bark.day.app/#/en-us/tutorial) to obtain your key.
+
+### [MQTT]
+`Host` = MQTT broker hostname or IP address. Required.\
+`Port` = MQTT broker port. Defaults to `1883`, or `8883` when `UseTls=true`.\
+`Topic` = MQTT topic to publish notifications to. Required.\
+`Username` = Optional broker username.\
+`Password` = Optional broker password.\
+`UseTls` = Whether to use TLS. Set to `true` or `false`; defaults to `false`.
 
 ### [Hoppie]
 `Enabled` = Whether or not to relay Hoppie messages. Set to `true` or `false`\

--- a/bin/Debug/vPilot-Pushover.ini
+++ b/bin/Debug/vPilot-Pushover.ini
@@ -21,6 +21,14 @@ NotificationGroup=vPilot
 Url=
 Token=
 
+[MQTT]
+Host=
+Port=1883
+Topic=vPilot
+Username=
+Password=
+UseTls=false
+
 [Hoppie]
 Enabled=false
 LogonCode=

--- a/bin/Release/vPilot-Pushover.ini
+++ b/bin/Release/vPilot-Pushover.ini
@@ -21,6 +21,14 @@ NotificationGroup=vPilot
 Url=
 Token=
 
+[MQTT]
+Host=
+Port=1883
+Topic=vPilot
+Username=
+Password=
+UseTls=false
+
 [Hoppie]
 Enabled=false
 LogonCode=

--- a/mqtt.md
+++ b/mqtt.md
@@ -1,6 +1,6 @@
 # MQTT setup
 
-This guide explains how to configure vPilot-Pushover to publish notifications to an MQTT broker, and how to consume those messages in Home Assistant.
+Use MQTT if you want vPilot-Pushover to publish notifications to an MQTT broker and let Home Assistant handle the delivery. This is a simple way to centralize vPilot traffic in Home Assistant without relying on a specific mobile app integration.
 
 ## What this does
 
@@ -20,3 +20,96 @@ Example payload:
   "priority": 0,
   "source": "startup message"
 }
+```
+
+---
+
+## 1) Configure vPilot-Pushover
+
+In your vPilot-Pushover.ini file, set the driver to MQTT and fill in the MQTT section.
+
+```ini
+[General]
+Driver = mqtt
+
+[MQTT]
+Host = 192.168.1.50
+Port = 1883
+Topic = vPilot
+Username = myuser
+Password = mypassword
+UseTls = false
+```
+
+### Settings
+
+- Host: MQTT broker hostname or IP address
+- Port: MQTT broker port. Usually 1883 for normal MQTT or 8883 for TLS
+- Topic: MQTT topic to publish messages to
+- Username: Optional broker username
+- Password: Optional broker password
+- UseTls: Set to true or false
+
+If Port is left blank, vPilot-Pushover will default to 1883 or 8883 depending on TLS.
+
+---
+
+## 2) Home Assistant automation
+
+You do not need to add the vPilot-Pushover app as a device in the MQTT integration. This is just a topic-based notification flow. Home Assistant only needs the MQTT integration enabled and an automation listening to the topic.
+
+This automation listens for messages on the MQTT topic and sends them to Home Assistant's generic notification service.
+
+```yaml
+alias: Vpilot Notifications handler
+description: "Listen for MQTT messages from vPilot-Pushover and forward them as Home Assistant notifications"
+triggers:
+  - trigger: mqtt
+    topic: vPilot
+conditions:
+  - condition: template
+    value_template: '{{ trigger.payload_json.priority | int >= 1 }}'
+actions:
+  - action: notify.notify
+    data:
+      title: "{{ trigger.payload_json.title }}"
+      message: "{{ trigger.payload_json.message }}"
+mode: single
+```
+
+## 3) Example with a persistent notification
+
+```yaml
+alias: Vpilot Notifications
+description: "Create a persistent Home Assistant notification from vPilot MQTT messages"
+triggers:
+  - trigger: mqtt
+    topic: vPilot
+conditions:
+  - condition: template
+    value_template: '{{ trigger.payload_json.priority | int >= 1 }}'
+actions:
+  - action: persistent_notification.create
+    data:
+      title: "{{ trigger.payload_json.title }}"
+      message: |
+        {{ trigger.payload_json.message }}
+        Source: {{ trigger.payload_json.source }}
+        Priority: {{ trigger.payload_json.priority }}
+```
+
+---
+
+## 4) Troubleshooting
+
+- Check that your MQTT broker is running and reachable
+- Make sure the topic matches exactly between vPilot-Pushover and Home Assistant
+- Confirm the MQTT integration is enabled in Home Assistant
+- Verify username/password if the broker requires authentication
+- If using TLS, make sure UseTls is true and the port matches your broker configuration
+
+---
+
+## 5) Notes
+
+This setup is useful if you want Home Assistant to act as your notification manager for vPilot traffic. It is simple, flexible, and works well with automations, alerts, and mobile notifications without requiring a special MQTT device definition.

--- a/mqtt.md
+++ b/mqtt.md
@@ -1,0 +1,22 @@
+# MQTT setup
+
+This guide explains how to configure vPilot-Pushover to publish notifications to an MQTT broker, and how to consume those messages in Home Assistant.
+
+## What this does
+
+When the MQTT driver is enabled, vPilot-Pushover connects to your broker and publishes a JSON payload to the topic you choose. The payload contains:
+
+- title
+- message
+- priority
+- source
+
+Example payload:
+
+```json
+{
+  "title": "vPilot connected",
+  "message": "Connected. Running version v1.2.3",
+  "priority": 0,
+  "source": "startup message"
+}

--- a/vPilot-Pushover.csproj
+++ b/vPilot-Pushover.csproj
@@ -32,11 +32,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
+    <!-- Set VpilotPluginsPath in Directory.Build.props or pass -p:VpilotPluginsPath=... -->
+    <VpilotPluginsPath Condition="'$(VpilotPluginsPath)' == '' and '$(VPILOT_PLUGINS_DLL)' != ''">$(VPILOT_PLUGINS_DLL)</VpilotPluginsPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="RossCarlson.Vatsim.Vpilot.Plugins, Version=3.9.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>F:\VATSIM\vPilot\RossCarlson.Vatsim.Vpilot.Plugins.dll</HintPath>
+      <HintPath>$(VpilotPluginsPath)</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/vPilot-Pushover.csproj
+++ b/vPilot-Pushover.csproj
@@ -47,6 +47,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Xml" />

--- a/vPilot-Pushover.csproj
+++ b/vPilot-Pushover.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Drivers\Pushover.cs" />
     <Compile Include="Drivers\Telegram.cs" />
     <Compile Include="Drivers\Bark.cs" />
+    <Compile Include="Drivers\Mqtt.cs" />
     <Compile Include="Http.cs" />
     <Compile Include="IniFile.cs" />
     <Compile Include="INotifier.cs" />


### PR DESCRIPTION
## Summary

This PR adds MQTT support as a new notification target for vPilot-Pushover. It allows notifications to be sent to an MQTT broker so they can be consumed by Home Assistant, automation tools, dashboards, or custom integrations.

## What I did

- Added an MQTT notifier implementation
- Configured connection to a broker using host, port, topic, and optional credentials
- Added support for TLS-secured MQTT connections
- Publishes notification payloads as JSON to the configured topic
- Included message metadata such as title, text, priority, and source
- Integrated the notifier with the existing configuration and error-handling flow

## Why

I wanted to use my Home Assistant instance as the notification manager for my vPilot alerts. This makes it possible to route notifications into Home Assistant automations, dashboards, and other MQTT-based workflows without relying on a single vendor-specific service. Also since I'm a C# dev i thought i could help and since I'm not the only one her it is (https://github.com/blt950/vPilot-Pushover/issues/42).

## Documentation

I will add documentation showing how to configure the MQTT notifier and how to use it with Home Assistant as a notification manager.